### PR TITLE
feat(blueprint): add Engineering Blueprint theme with toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ vite.config.ts.timestamp-*
 
 # Private data
 static/data/*.json
+
+# Local tooling
+.claude/
+.mcp.json

--- a/src/app.css
+++ b/src/app.css
@@ -350,3 +350,599 @@ body {
     box-shadow: none;
   }
 }
+
+/* =============================================
+   ENGINEERING BLUEPRINT THEME
+   ============================================= */
+
+[data-theme="blueprint"] {
+  --color-primary: #1a3a6b;
+  --color-secondary: #2c2c2c;
+  --color-accent: #8b1a1a;
+  --color-background: #f4f1e8;
+  --color-surface: #ede9dc;
+  --color-surface-light: #e8e4d5;
+  --color-foreground: #111111;
+  --color-muted: #555555;
+  --color-border: #1a3a6b;
+  --color-danger: #8b0000;
+  --color-warning: #5a3e00;
+  --color-success: #1a4a1a;
+  --color-neon-purple: #1a3a6b;
+  --color-neon-green: #1a4a1a;
+
+  /* Override legacy vars */
+  --color-rdark: #e8e4d5;
+  --color-rblue: #1a3a6b;
+  --color-rpink: #2c2c2c;
+  --color-rorng: #8b1a1a;
+  --color-ryllw: #8b1a1a;
+}
+
+/* ---------------------------------------------
+   Blueprint design system — drawing primitives
+   Used by the dedicated blueprint layout in
+   src/lib/blueprint/*. These are a separate visual
+   language from the retro components, not overrides.
+   --------------------------------------------- */
+
+:root {
+  --bp-ink: #111111;          /* black drafting ink */
+  --bp-ink-strong: #000000;
+  --bp-paper: #f4f1e8;        /* warm off-white drafting paper */
+  --bp-paper-2: #efebdd;
+  --bp-red: #8b1a1a;          /* revision / annotation red accent */
+  --bp-graphite: #1a1a1a;
+  --bp-line: rgba(17, 17, 17, 0.5);
+  --bp-line-soft: rgba(17, 17, 17, 0.18);
+}
+
+.bp-root {
+  font-family: 'Courier New', 'Courier', monospace;
+  color: var(--bp-graphite);
+  letter-spacing: 0.02em;
+}
+
+/* Drafting paper + graph grid */
+.bp-paper-bg {
+  background-color: var(--bp-paper);
+  /* faint drafting dot-grid — dots sit at 24px intersections */
+  background-image: radial-gradient(rgba(17, 17, 17, 0.11) 0.9px, transparent 1px);
+  background-size: 24px 24px;
+}
+
+/* Outer drawing border (double rule like a real sheet) */
+
+/* Zone tick marks along the margins (1 2 3 4 / A B C D) */
+.bp-zone {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--bp-ink);
+  letter-spacing: 0.1em;
+}
+
+/* Generic drawing panel */
+.bp-panel {
+  border: 1.5px solid var(--bp-ink);
+  background: rgba(244, 241, 232, 0.6);
+  position: relative;
+}
+
+.bp-panel-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-50%);
+  margin-left: 12px;
+  padding: 1px 8px;
+  background: var(--bp-paper);
+  border: 1px solid var(--bp-ink);
+  color: var(--bp-ink);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+/* Section title — drawing sheet heading */
+.bp-title {
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--bp-ink-strong);
+}
+
+/* Dimension line with end ticks */
+.bp-dim {
+  position: relative;
+  height: 13px;
+  /* the rule itself is a background line so it can be "drawn" by growing width */
+  background: linear-gradient(var(--bp-ink), var(--bp-ink)) no-repeat left center;
+  background-size: 100% 1px;
+}
+.bp-dim::before,
+.bp-dim::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  width: 1px;
+  height: 13px;
+  background: var(--bp-ink);
+  /* 45° oblique tick — the standard architectural dimension stroke */
+  transform: rotate(45deg);
+}
+.bp-dim::before { left: 0; }
+.bp-dim::after { right: 0; }
+
+.bp-dim-value {
+  font-size: 10px;
+  color: var(--bp-ink);
+  background: var(--bp-paper);
+  padding: 0 4px;
+}
+
+/* Leader line callout (annotation pointing to something) */
+.bp-callout {
+  position: relative;
+  padding-left: 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--bp-graphite);
+}
+.bp-callout::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.7em;
+  width: 8px;
+  height: 1px;
+  background: var(--bp-ink);
+}
+.bp-callout::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: calc(0.7em - 2px);
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  border: 1px solid var(--bp-ink);
+  background: var(--bp-paper);
+  transform: translateX(-2px);
+}
+
+/* Balloon (part number marker, like assembly callouts) */
+.bp-balloon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 1.5px solid var(--bp-ink);
+  background: var(--bp-paper);
+  color: var(--bp-ink);
+  font-size: 12px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+/* Technical tables (BOM / revision history) */
+.bp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.bp-table th,
+.bp-table td {
+  border: 1px solid var(--bp-line);
+  padding: 5px 8px;
+  text-align: left;
+  vertical-align: top;
+}
+.bp-table th {
+  background: rgba(17, 17, 17, 0.05);
+  color: var(--bp-ink-strong);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 10px;
+}
+
+/* Spec chip (part token) */
+.bp-chip {
+  display: inline-block;
+  border: 1px solid var(--bp-ink);
+  padding: 2px 7px;
+  font-size: 11px;
+  color: var(--bp-ink);
+  background: var(--bp-paper);
+  letter-spacing: 0.04em;
+}
+
+/* The "switch to retro" button previews the retro theme: dark panel, neon
+   cyan glow, arcade font — so it pops against the clean blueprint header. */
+.bp-retro-toggle {
+  background: #050a14;
+  border: 1.5px solid #13b6ec;
+  color: #13b6ec;
+  font-family: "RetroGaming", "PressStart", monospace;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 6px 14px;
+  cursor: pointer;
+  text-shadow: 0 0 8px rgba(19, 182, 236, 0.7);
+  box-shadow:
+    inset 0 0 9px rgba(19, 182, 236, 0.3),
+    0 0 6px rgba(19, 182, 236, 0.45);
+  transition: box-shadow 0.15s, color 0.15s;
+}
+.bp-retro-toggle:hover {
+  color: #ff00ff;
+  border-color: #ff00ff;
+  text-shadow: 0 0 8px rgba(255, 0, 255, 0.7);
+  box-shadow:
+    inset 0 0 9px rgba(255, 0, 255, 0.3),
+    0 0 8px rgba(255, 0, 255, 0.5);
+}
+
+/* Nav tab styled as a drawing view selector */
+.bp-tab {
+  position: relative;
+  border: 1.5px solid var(--bp-ink);
+  background: var(--bp-paper);
+  color: var(--bp-ink);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 6px 14px;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.bp-tab:hover { background: rgba(17, 17, 17, 0.06); }
+/* keep the label above the hatch fill of the active tab */
+.bp-tab-label {
+  position: relative;
+  z-index: 1;
+}
+/* Selected tab: hatched fill with the name in white + a black outline so it
+   stays legible wherever the hatch lines fall. */
+.bp-tab[data-active="true"] {
+  background: var(--bp-paper);
+  color: var(--bp-paper);
+  font-weight: 800;
+}
+.bp-tab[data-active="true"] .bp-tab-label {
+  /* white fill with a crisp black outline (built from layered shadows) so the
+     name reads cleanly wherever the hatch lines fall behind it */
+  text-shadow:
+    -1px -1px 0 var(--bp-ink), 0 -1px 0 var(--bp-ink), 1px -1px 0 var(--bp-ink),
+    -1px 0 0 var(--bp-ink), 1px 0 0 var(--bp-ink),
+    -1px 1px 0 var(--bp-ink), 0 1px 0 var(--bp-ink), 1px 1px 0 var(--bp-ink);
+}
+.bp-tab[data-active="true"]::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--bp-ink) 0,
+    var(--bp-ink) 1px,
+    transparent 1px,
+    transparent 5px
+  );
+  opacity: 0.55;
+  z-index: 0;
+  pointer-events: none;
+}
+
+/* Title block (bottom-right of every real drawing) */
+.bp-titleblock {
+  border: 1.5px solid var(--bp-ink);
+  background: var(--bp-paper);
+  font-size: 11px;
+  color: var(--bp-graphite);
+}
+.bp-titleblock .cell {
+  border: 1px solid var(--bp-line);
+  padding: 4px 8px;
+}
+.bp-titleblock .k {
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--bp-ink);
+  display: block;
+}
+.bp-titleblock .v {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--bp-ink-strong);
+}
+
+/* Viewport frame for the profile photo (orthographic view box) */
+.bp-viewport {
+  border: 1.5px solid var(--bp-ink);
+  background: var(--bp-paper);
+  position: relative;
+  padding: 8px;
+}
+.bp-viewport::before,
+.bp-viewport::after {
+  content: "";
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border: 1px solid var(--bp-ink);
+}
+.bp-viewport::before { top: -1px; left: -1px; border-right: none; border-bottom: none; }
+.bp-viewport::after { bottom: -1px; right: -1px; border-left: none; border-top: none; }
+.bp-viewport img { filter: grayscale(100%) contrast(1.05); display: block; width: 100%; }
+
+/* Center-mark crosshair */
+.bp-crosshair {
+  position: relative;
+}
+.bp-crosshair::before,
+.bp-crosshair::after {
+  content: "";
+  position: absolute;
+  background: var(--bp-line);
+}
+.bp-crosshair::before { left: 50%; top: 0; bottom: 0; width: 1px; transform: translateX(-0.5px); }
+.bp-crosshair::after { top: 50%; left: 0; right: 0; height: 1px; transform: translateY(-0.5px); }
+
+/* 45° hatching — fills empty (no-text) areas so the boxes on top of it pop. */
+.bp-hatch {
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--bp-ink) 0,
+    var(--bp-ink) 0.75px,
+    transparent 0.75px,
+    transparent 5px
+  );
+}
+
+/* Hatch layer that sits behind the title block (fills the empty part of the
+   bottom strip), making the name box pop. */
+.bp-hatchfill {
+  position: absolute;
+  inset: 0;
+  opacity: 0.4;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ---------------------------------------------
+   Sheet heading with drawn underline.
+   Static by default; the rule is "drawn" left to
+   right only when motion is allowed (see below).
+   --------------------------------------------- */
+.bp-sheet-head {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding-bottom: 0.5rem;
+  margin-bottom: 2rem;
+}
+.bp-sheet-head::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 2px;
+  width: 100%;
+  background: var(--bp-ink);
+}
+
+/* ---------------------------------------------
+   Hand-drawn box animation.
+   Every box — the outer sheet frame and each inner
+   panel — is bordered by four <span class="bp-edge">
+   line elements instead of a CSS border. A pen draws
+   them one at a time: all the verticals, then all the
+   horizontals — or the reverse, chosen at random per
+   box via [data-order]. Contents appear only once the
+   box is fully traced.
+
+   Section components remount on every tab switch, so
+   inner boxes re-draw each time a sheet is shown; the
+   outer frame draws once, when blueprint mounts.
+   --------------------------------------------- */
+@keyframes bpGrowH { from { width: 0; } to { width: 100%; } }
+@keyframes bpGrowV { from { height: 0; } to { height: 100%; } }
+@keyframes bpDrawLine { from { width: 0; } to { width: 100%; } }
+@keyframes bpSettle {
+  from { opacity: 0; transform: translateY(7px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes bpFade { from { opacity: 0; } to { opacity: 1; } }
+/* Typewriter: a character sits faint until its turn, then snaps to full dark. */
+@keyframes twType {
+  from { opacity: 0.22; }
+  to   { opacity: 1; }
+}
+/* Balloon ring drawn like a compass sweep. */
+@property --bp-ang {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+@keyframes bpRing {
+  from { --bp-ang: 0deg; }
+  to   { --bp-ang: 360deg; }
+}
+/* Hatching is drawn from one end to the other (left to right wipe). */
+@keyframes bpHatchDraw {
+  from { clip-path: inset(0 100% 0 0); }
+  to   { clip-path: inset(0 0 0 0); }
+}
+/* Dimension rule drawn from left to right. */
+@keyframes bpDimGrow {
+  from { background-size: 0% 1px; }
+  to   { background-size: 100% 1px; }
+}
+
+/* Edge lines are hidden unless motion is allowed, so
+   reduced-motion users keep the plain static borders. */
+.bp-edge { display: none; }
+
+/* ===== Two stacked sheet boxes (header + body) =====
+   In reduced motion they show static borders; the body has no top border
+   so it shares the header's bottom line, making the pair read as one box. */
+.bp-hdr,
+.bp-body {
+  position: relative;
+  border: 2px solid var(--bp-ink);
+}
+.bp-body {
+  border-top: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  /* Edge geometry — shared by the big boxes and the panels.
+     Each line starts collapsed along its drawing axis. */
+  .bp-edge {
+    display: block;
+    position: absolute;
+    background: var(--bp-ink);
+    pointer-events: none;
+  }
+  .e-top    { top: 0;    left: 0;  height: 1.5px; width: 0; }
+  .e-bottom { bottom: 0; left: 0;  height: 1.5px; width: 0; }
+  .e-left   { top: 0;    left: 0;  width: 1.5px;  height: 0; }
+  .e-right  { top: 0;    right: 0; width: 1.5px;  height: 0; }
+
+  /* Order in which a box's four lines are drawn. Direct-child edges only,
+     so a box inside another box keeps its own independent draw order.
+     v = verticals first (left, right) then horizontals; h = the reverse. */
+  [data-order="v"] > .e-left   { animation: bpGrowV var(--ld) linear calc(var(--b) + 0 * var(--ld)) forwards; }
+  [data-order="v"] > .e-right  { animation: bpGrowV var(--ld) linear calc(var(--b) + 1 * var(--ld)) forwards; }
+  [data-order="v"] > .e-top    { animation: bpGrowH var(--ld) linear calc(var(--b) + 2 * var(--ld)) forwards; }
+  [data-order="v"] > .e-bottom { animation: bpGrowH var(--ld) linear calc(var(--b) + 3 * var(--ld)) forwards; }
+
+  [data-order="h"] > .e-top    { animation: bpGrowH var(--ld) linear calc(var(--b) + 0 * var(--ld)) forwards; }
+  [data-order="h"] > .e-bottom { animation: bpGrowH var(--ld) linear calc(var(--b) + 1 * var(--ld)) forwards; }
+  [data-order="h"] > .e-left   { animation: bpGrowV var(--ld) linear calc(var(--b) + 2 * var(--ld)) forwards; }
+  [data-order="h"] > .e-right  { animation: bpGrowV var(--ld) linear calc(var(--b) + 3 * var(--ld)) forwards; }
+
+  /* ---- The two big boxes: no static border (edges draw it), thick lines ---- */
+  .bp-bigbox {
+    border-width: 0;
+    --ld: 0.28s;                          /* slower, deliberate strokes */
+    --b: 0s;
+    --box-draw: 1.12s;                    /* 4 lines x 0.28s */
+  }
+  .bp-bigbox > .e-top,
+  .bp-bigbox > .e-bottom { height: 2px; }
+  .bp-bigbox > .e-left,
+  .bp-bigbox > .e-right { width: 2px; }
+
+  /* Body contents (panels, title block, heading) only begin once the
+     body box has finished drawing. */
+  .bp-body-in { --bp-base: var(--box-draw); }
+
+  /* ---- Inner panels: cascade serially after the body box ---- */
+  .bp-panel {
+    border-color: transparent;           /* edges provide the border */
+    --bp-i: 0;                            /* cascade order on the sheet */
+    --bp-step: 0.32s;                     /* gap between cascading boxes */
+    --ld: 0.17s;                          /* time to draw one line */
+    --b: calc(var(--bp-base, 0s) + var(--bp-i) * var(--bp-step));
+    /* when this box's contents appear — chips inside draw at this moment.
+       Kept free of var(--b) to avoid a cycle when a chip redefines --b. */
+    --content-at: calc(1.7s + var(--bp-i) * 0.32s);
+  }
+  .bp-panel-label {
+    z-index: 2;                            /* sit above the drawn edge */
+    /* the block fades in faint as its box is drawn... */
+    animation: bpFade calc(4 * var(--ld)) ease-out var(--b) backwards;
+  }
+
+  /* Each text block fades in faint while its box is drawn; the characters
+     inside then type to full dark one-by-one (see the `typewriter` action). */
+  .bp-box-content {
+    animation: bpFade calc(4 * var(--ld)) ease-out var(--b) backwards;
+  }
+  .bp-hdr-in,
+  .bp-titleblock {
+    animation: bpFade var(--box-draw) ease-out 0s backwards;
+  }
+
+  /* ...and the characters type in: faint until their turn, then snap to dark.
+     The per-character animation-delay is set inline by the typewriter action. */
+  .tw-char {
+    animation: twType 0.16s ease-out backwards;
+  }
+
+  /* Chips (rectangles) get the same one-line-at-a-time draw as the boxes:
+     four edge spans (added by the drawEdges action) traced in a random order,
+     timed to when their box's contents appear. */
+  .bp-chip {
+    position: relative;
+    border-width: 0;                      /* drawn edges are the border */
+    --b: var(--content-at, 1.7s);
+    --ld: 0.07s;                          /* fast — chips are small */
+  }
+  .bp-chip > .e-top,
+  .bp-chip > .e-bottom { height: 1px; }
+  .bp-chip > .e-left,
+  .bp-chip > .e-right { width: 1px; }
+
+  /* Balloons (circles) draw their ring with a compass-like sweep. */
+  .bp-balloon {
+    position: relative;
+    border-color: transparent;
+  }
+  .bp-balloon::before {
+    content: "";
+    position: absolute;
+    inset: -1.5px;
+    border-radius: 50%;
+    background: conic-gradient(var(--bp-ink) 0deg var(--bp-ang), transparent var(--bp-ang));
+    -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 1.5px), #000 calc(100% - 1.5px));
+    mask: radial-gradient(farthest-side, transparent calc(100% - 1.5px), #000 calc(100% - 1.5px));
+    pointer-events: none;
+    animation: bpRing 0.5s ease-out calc(var(--b, 1s) + 4 * var(--ld, 0.17s)) both;
+  }
+
+  /* ---- Heading underline traces left to right (after the body box) ---- */
+  .bp-sheet-head::after {
+    width: 0;
+    animation: bpDrawLine 0.9s ease-out calc(var(--bp-base, 0s) + 0.1s) forwards;
+  }
+  .bp-sheet-head > * {
+    animation: bpFade var(--box-draw, 1.12s) ease-out 0s backwards;
+  }
+
+  /* Photo viewport — fades in at its cascade slot */
+  .bp-viewport {
+    animation: bpSettle 0.8s ease-out calc(var(--bp-base, 0s) + var(--bp-i, 0) * var(--bp-step, 0.32s) + 0.2s) backwards;
+  }
+
+  /* Dimension rule draws left to right; its end ticks fade in at each end. */
+  .bp-dim {
+    animation: bpDimGrow 0.5s ease-out var(--dim-delay, 1.3s) both;
+  }
+  .bp-dim::before {
+    animation: bpFade 0.2s ease-out var(--dim-delay, 1.3s) both;
+  }
+  .bp-dim::after {
+    animation: bpFade 0.2s ease-out calc(var(--dim-delay, 1.3s) + 0.42s) both;
+  }
+
+  /* Hatching draws itself from one end to the other. */
+  .bp-hatch {
+    clip-path: inset(0 100% 0 0);
+    animation: bpHatchDraw 0.8s ease-out var(--hatch-delay, 1.5s) forwards;
+  }
+  /* The selected tab's hatch draws in (also re-runs each time a tab is picked,
+     because the rule starts matching when data-active flips to true). */
+  .bp-tab[data-active="true"]::before {
+    clip-path: inset(0 100% 0 0);
+    animation: bpHatchDraw 0.4s ease-out forwards;
+  }
+}

--- a/src/lib/ThemeToggle.svelte
+++ b/src/lib/ThemeToggle.svelte
@@ -1,0 +1,38 @@
+<script>
+	import { theme } from '$lib/stores/theme.js';
+</script>
+
+<!-- Shown in the retro theme; styled like the engineering blueprint theme it
+     switches to (off-white paper, black ink, monospace, sharp corners). -->
+<button
+	on:click={theme.toggle}
+	title="Switch to engineering blueprint theme"
+	class="blueprint-toggle"
+>
+	<span class="material-symbols-outlined" style="font-size: 16px;">architecture</span>
+	BLUEPRINT
+</button>
+
+<style>
+	.blueprint-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		background: #f4f1e8;
+		color: #111111;
+		border: 2px solid #111111;
+		border-radius: 0;
+		font-family: 'Courier New', monospace;
+		font-weight: 700;
+		font-size: 12px;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		padding: 7px 12px;
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s;
+	}
+	.blueprint-toggle:hover {
+		background: #111111;
+		color: #f4f1e8;
+	}
+</style>

--- a/src/lib/blueprint/BlueprintShell.svelte
+++ b/src/lib/blueprint/BlueprintShell.svelte
@@ -1,0 +1,217 @@
+<script>
+	import { theme } from '$lib/stores/theme.js';
+	import BpAbout from './BpAbout.svelte';
+	import BpHighlights from './BpHighlights.svelte';
+	import BpProjects from './BpProjects.svelte';
+	import BpCV from './BpCV.svelte';
+	import { typewriter } from './typewriter.js';
+
+	let currentSection = 'about';
+
+	// The sheet is two stacked drawn boxes sharing a divider line so they read
+	// as one big box. The HEADER box (nav/identity/tabs) is common to every
+	// section, so it draws once on first load and then stays put. The BODY box
+	// (section content + title block) is re-keyed on each section change so it
+	// redraws at the new content size. Each box draws its four lines one at a
+	// time in a random order; the body re-randomises on every change.
+	const hdrOrder = Math.random() < 0.5 ? 'v' : 'h';
+	let bodyOrder = Math.random() < 0.5 ? 'v' : 'h';
+
+	function selectView(id) {
+		if (id === currentSection) return;
+		currentSection = id;
+		bodyOrder = Math.random() < 0.5 ? 'v' : 'h';
+	}
+
+	const views = [
+		{ id: 'about', no: '01', label: 'ABOUT', code: 'GENERAL ARRANGEMENT' },
+		{ id: 'highlights', no: '02', label: 'HIGHLIGHTS', code: 'BILL OF MATERIALS' },
+		{ id: 'projects', no: '03', label: 'PROJECTS', code: 'ASSEMBLY DRAWINGS' },
+		{ id: 'cv', no: '04', label: 'CV', code: 'REVISION HISTORY' }
+	];
+
+	const sheetNo = { about: '01', highlights: '02', projects: '03', cv: '04' };
+	const today = new Date().toISOString().slice(0, 10);
+
+	// Zone markers along the margins
+	const cols = [1, 2, 3, 4, 5, 6, 7, 8];
+	const rows = ['A', 'B', 'C', 'D'];
+</script>
+
+<div class="bp-root bp-paper-bg min-h-screen w-full">
+	<div class="mx-auto max-w-[1320px] px-3 py-4 md:px-6 md:py-6">
+		<div class="bp-sheet-wrap">
+			<!-- ===== HEADER BOX — common, draws once on first load ===== -->
+			<div class="bp-hdr bp-bigbox" data-order={hdrOrder}>
+				<span class="bp-edge e-top" aria-hidden="true"></span>
+				<span class="bp-edge e-bottom" aria-hidden="true"></span>
+				<span class="bp-edge e-left" aria-hidden="true"></span>
+				<span class="bp-edge e-right" aria-hidden="true"></span>
+
+				<div class="bp-hdr-in" use:typewriter={{ done: 1120, duration: 1150 }}>
+					<!-- Top margin ruler: zone numbers + retro toggle -->
+					<div class="flex items-stretch border-b-2" style="border-color: var(--bp-ink);">
+						<div class="flex flex-1 items-center">
+							{#each cols as c}
+								<div
+									class="bp-zone flex h-8 flex-1 items-center justify-center border-r"
+									style="border-color: var(--bp-line-soft);"
+								>
+									{c}
+								</div>
+							{/each}
+						</div>
+						<a
+							href="mailto:devsoham3@gmail.com"
+							class="bp-tab flex items-center gap-1.5 border-y-0 border-r-0 border-l-2"
+							style="border-color: var(--bp-ink);"
+							title="Contact me"
+						>
+							<span class="material-symbols-outlined text-[16px]">mail</span> CONTACT
+						</a>
+						<button
+							on:click={theme.toggle}
+							class="bp-retro-toggle tw-skip flex items-center gap-1.5"
+							title="Switch to retro theme"
+						>
+							<span class="material-symbols-outlined text-[16px]">videogame_asset</span> RETRO MODE
+						</button>
+					</div>
+
+					<!-- Identity bar + view selector -->
+					<div
+						class="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+					>
+						<div class="flex items-center gap-3">
+							<span class="bp-balloon" style="width:30px;height:30px;">SD</span>
+							<div>
+								<p class="bp-title text-sm leading-tight" style="color: var(--bp-ink-strong);">
+									Soham Deo — Portfolio
+								</p>
+								<p class="text-[10px]" style="color: var(--bp-ink);">
+									DRAWING No. SD-2026 · TECHNICAL DATA SHEET
+								</p>
+							</div>
+						</div>
+						<div class="flex flex-wrap gap-2">
+							{#each views as view}
+								<button
+									class="bp-tab"
+									data-active={currentSection === view.id}
+									on:click={() => selectView(view.id)}
+								>
+									<span class="bp-tab-label">{view.no} · {view.label}</span>
+								</button>
+							{/each}
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<!-- ===== BODY BOX — section content, redraws on change ===== -->
+			{#key currentSection}
+				<div class="bp-body bp-bigbox" data-order={bodyOrder}>
+					<span class="bp-edge e-top" aria-hidden="true"></span>
+					<span class="bp-edge e-bottom" aria-hidden="true"></span>
+					<span class="bp-edge e-left" aria-hidden="true"></span>
+					<span class="bp-edge e-right" aria-hidden="true"></span>
+
+					<div class="bp-body-in">
+						<!-- Drawing area with side zone markers -->
+						<div class="flex">
+							<div
+								class="hidden flex-col border-r md:flex"
+								style="border-color: var(--bp-line-soft);"
+							>
+								{#each rows as r}
+									<div class="bp-zone flex w-7 flex-1 items-center justify-center">{r}</div>
+								{/each}
+							</div>
+
+							<main class="bp-content min-h-[60vh] flex-1 px-5 py-8 md:px-10 md:py-10">
+								{#if currentSection === 'about'}
+									<BpAbout />
+								{:else if currentSection === 'highlights'}
+									<BpHighlights />
+								{:else if currentSection === 'projects'}
+									<BpProjects />
+								{:else if currentSection === 'cv'}
+									<BpCV />
+								{/if}
+							</main>
+
+							<div
+								class="hidden flex-col border-l md:flex"
+								style="border-color: var(--bp-line-soft);"
+							>
+								{#each rows as r}
+									<div class="bp-zone flex w-7 flex-1 items-center justify-center">{r}</div>
+								{/each}
+							</div>
+						</div>
+
+						<!-- Title block (bottom-right, like a real drawing) -->
+						<div
+							class="relative flex justify-end border-t-2 p-3"
+							style="border-color: var(--bp-ink);"
+						>
+							<!-- hatched fill behind the title block so the name box pops -->
+							<span class="bp-hatch bp-hatchfill" style="--hatch-delay: 1.7s;" aria-hidden="true"></span>
+							<div
+								class="bp-titleblock relative z-[1] grid w-full grid-cols-2 sm:w-auto sm:grid-cols-4"
+								use:typewriter={{ done: 1370, duration: 900 }}
+							>
+								<div class="cell">
+									<span class="k">Drawn By</span>
+									<span class="v">S. DEO</span>
+								</div>
+								<div class="cell">
+									<span class="k">Date</span>
+									<span class="v">{today}</span>
+								</div>
+								<div class="cell">
+									<span class="k">Scale</span>
+									<span class="v">1:1</span>
+								</div>
+								<div class="cell">
+									<span class="k">Sheet</span>
+									<span class="v">{sheetNo[currentSection]} / 04</span>
+								</div>
+								<div class="cell col-span-2 sm:col-span-3">
+									<span class="k">Title</span>
+									<span class="v">{views.find((v) => v.id === currentSection)?.code}</span>
+								</div>
+								<div class="cell">
+									<span class="k">Rev</span>
+									<span class="v">A</span>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			{/key}
+		</div>
+
+		<!-- Contact strip under the sheet -->
+		<div
+			class="mt-4 flex flex-wrap items-center justify-between gap-3 text-[11px]"
+			style="color: var(--bp-ink);"
+			use:typewriter={{ done: 1900, duration: 800 }}
+		>
+			<span>© {new Date().getFullYear()} SOHAM DEO · ALL DIMENSIONS IN CONFIDENCE</span>
+			<div class="flex gap-4">
+				<a href="mailto:devsoham3@gmail.com" class="underline-offset-2 hover:underline">EMAIL</a>
+				<a
+					href="https://linkedin.com/in/devsoham3"
+					target="_blank"
+					class="underline-offset-2 hover:underline">LINKEDIN</a
+				>
+				<a
+					href="https://github.com/devSoham3"
+					target="_blank"
+					class="underline-offset-2 hover:underline">GITHUB</a
+				>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/lib/blueprint/BpAbout.svelte
+++ b/src/lib/blueprint/BpAbout.svelte
@@ -1,0 +1,93 @@
+<script>
+	import { onMount } from 'svelte';
+	import BpBox from './BpBox.svelte';
+	import { typewriter } from './typewriter.js';
+	import { drawEdges } from './drawEdges.js';
+	let aboutData = null;
+	let error = null;
+
+	onMount(async () => {
+		try {
+			const res = await fetch('/data/about.json');
+			aboutData = await res.json();
+		} catch (err) {
+			error = err;
+		}
+	});
+</script>
+
+<section class="bp-root">
+	{#if error}
+		<p style="color: var(--bp-red);">// DRAWING DATA NOT FOUND — REF about.json</p>
+	{:else if aboutData}
+		<!-- Sheet heading -->
+		<div class="bp-sheet-head" use:typewriter={{ done: 1260, duration: 700 }}>
+			<div>
+				<h1 class="bp-title text-2xl md:text-3xl">About</h1>
+				<p class="mt-1 text-xs" style="color: var(--bp-ink);">
+					SHEET 01 — SUBJECT: {aboutData.name.toUpperCase()}
+				</p>
+			</div>
+			<p class="hidden text-right text-[10px] md:block" style="color: var(--bp-ink);">
+				PROJECTION: FIRST ANGLE<br />UNITS: mm
+			</p>
+		</div>
+
+		<div class="grid grid-cols-1 gap-10 lg:grid-cols-[300px_1fr]">
+			<!-- Orthographic view of subject -->
+			<div>
+				<div class="bp-viewport" style="--bp-i: 0">
+					<img src={aboutData.photo} alt={`Elevation view of ${aboutData.name}`} />
+				</div>
+				<!-- Horizontal dimension under the photo -->
+				<div class="mt-3 flex items-center gap-2">
+					<div class="bp-dim flex-1"></div>
+					<span class="bp-dim-value" use:typewriter={{ done: 1350, duration: 300 }}>FRONT ELEV.</span>
+					<div class="bp-dim flex-1"></div>
+				</div>
+				<!-- Location tag + material hatch swatch -->
+				<div class="mt-4 flex items-center gap-2">
+					<span class="bp-chip" use:drawEdges use:typewriter={{ done: 1450, duration: 250 }}>DATUM</span>
+					<span
+						class="text-xs"
+						style="color: var(--bp-graphite);"
+						use:typewriter={{ done: 1500, duration: 350 }}>{aboutData.location}</span
+					>
+				</div>
+				<div class="mt-3 flex items-center gap-2">
+					<span
+						class="bp-hatch inline-block h-5 w-10 border"
+						style="border-color: var(--bp-ink); --hatch-delay: 1.4s;"
+						aria-hidden="true"
+					></span>
+					<span
+						class="text-[10px] tracking-widest"
+						style="color: var(--bp-ink);"
+						use:typewriter={{ done: 1600, duration: 300 }}>SECTION A–A</span
+					>
+				</div>
+			</div>
+
+			<!-- Annotated specification / bio callouts -->
+			<BpBox label="Notes" i={1} cls="p-6 pt-7">
+				<h2 class="bp-title mb-1 text-lg" style="color: var(--bp-ink-strong);">
+					{aboutData.name}
+				</h2>
+				<p class="mb-5 text-xs tracking-widest" style="color: var(--bp-red);">
+					REV — SOFTWARE / DATA ENGINEER
+				</p>
+				<ul class="space-y-3">
+					{#each aboutData.description as line, i}
+						<li class="bp-callout">
+							<span class="mr-2 font-bold" style="color: var(--bp-ink);"
+								>{String(i + 1).padStart(2, '0')}.</span
+							>{line}
+						</li>
+					{/each}
+				</ul>
+			</BpBox>
+		</div>
+	{:else}
+		<p class="text-xs" style="color: var(--bp-ink);">LOADING SHEET 01…</p>
+	{/if}
+</section>

--- a/src/lib/blueprint/BpBox.svelte
+++ b/src/lib/blueprint/BpBox.svelte
@@ -1,0 +1,29 @@
+<script>
+	// A drawing "box": four edge lines that draw one at a time
+	// (vertical-first or horizontal-first, picked at random) plus a
+	// content slot whose text types in once the outline is complete.
+	import { typewriter } from './typewriter.js';
+
+	export let label = '';
+	export let i = 0; // cascade order on the sheet
+	export let cls = ''; // extra classes (padding, margins, etc.)
+
+	// Randomise per box whether the verticals or horizontals are drawn first
+	const order = Math.random() < 0.5 ? 'v' : 'h';
+
+	// Timing (ms) mirrors the CSS: body box draws ~1120ms, panels cascade
+	// 320ms apart, each panel's four lines take ~680ms. Text types once the
+	// panel's outline is finished.
+	const boxDone = 1120 + i * 320 + 680;
+</script>
+
+<div class="bp-panel {cls}" style="--bp-i: {i}" data-order={order}>
+	{#if label}
+		<span class="bp-panel-label" use:typewriter={{ done: boxDone - 120, duration: 380 }}>{label}</span>
+	{/if}
+	<span class="bp-edge e-top" aria-hidden="true"></span>
+	<span class="bp-edge e-bottom" aria-hidden="true"></span>
+	<span class="bp-edge e-left" aria-hidden="true"></span>
+	<span class="bp-edge e-right" aria-hidden="true"></span>
+	<div class="bp-box-content" use:typewriter={{ done: boxDone, duration: 1150 }}><slot /></div>
+</div>

--- a/src/lib/blueprint/BpCV.svelte
+++ b/src/lib/blueprint/BpCV.svelte
@@ -1,0 +1,188 @@
+<script>
+	import { onMount } from 'svelte';
+	import BpBox from './BpBox.svelte';
+	import { typewriter } from './typewriter.js';
+	import { drawEdges } from './drawEdges.js';
+	let cvData = null;
+	let error = null;
+
+	// Flatten all roles + education into revision rows
+	let revisions = [];
+
+	function buildRevisions(data) {
+		const rows = [];
+		for (const org of data.experience.work ?? []) {
+			for (const role of org.roles) {
+				rows.push({ kind: 'WORK', who: org.organization, what: role.role, when: role.duration });
+			}
+		}
+		for (const org of data.experience.academia ?? []) {
+			for (const role of org.roles) {
+				rows.push({ kind: 'ACAD', who: org.organization, what: role.role, when: role.duration });
+			}
+		}
+		for (const edu of data.education ?? []) {
+			rows.push({ kind: 'EDU', who: edu.institution, what: edu.degree, when: edu.duration });
+		}
+		for (const org of data.experience.others ?? []) {
+			for (const role of org.roles) {
+				rows.push({ kind: 'MISC', who: org.organization, what: role.role, when: role.duration });
+			}
+		}
+		return rows;
+	}
+
+	function asList(resp) {
+		return Array.isArray(resp) ? resp : [resp];
+	}
+
+	onMount(async () => {
+		try {
+			const res = await fetch('/data/cv.json');
+			cvData = await res.json();
+			revisions = buildRevisions(cvData);
+		} catch (err) {
+			error = err;
+		}
+	});
+</script>
+
+<section class="bp-root">
+	{#if error}
+		<p style="color: var(--bp-red);">// DRAWING DATA NOT FOUND — REF cv.json</p>
+	{:else if cvData}
+		<!-- Sheet heading -->
+		<div class="bp-sheet-head" use:typewriter={{ done: 1260, duration: 700 }}>
+			<div>
+				<h1 class="bp-title text-2xl md:text-3xl">CV</h1>
+				<p class="mt-1 text-xs" style="color: var(--bp-ink);">SHEET 04 — CAREER LOG</p>
+			</div>
+			<p class="hidden text-right text-[10px] md:block" style="color: var(--bp-ink);">
+				REVISIONS: {revisions.length}
+			</p>
+		</div>
+
+		<!-- Revision table -->
+		<BpBox i={0} cls="mb-10 p-1">
+			<table class="bp-table">
+				<thead>
+					<tr>
+						<th style="width: 48px;">Rev</th>
+						<th style="width: 88px;">Type</th>
+						<th style="width: 200px;">Date</th>
+						<th>Description</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each revisions as rev, i}
+						<tr>
+							<td style="font-weight: 700; color: var(--bp-ink);">
+								{String.fromCharCode(65 + (revisions.length - 1 - i))}
+							</td>
+							<td>
+								<span class="bp-chip" style="font-size: 9px;" use:drawEdges>{rev.kind}</span>
+							</td>
+							<td style="white-space: nowrap;">{rev.when}</td>
+							<td>
+								<span style="font-weight: 700;">{rev.what}</span>
+								<span style="color: var(--bp-ink);"> — {rev.who}</span>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</BpBox>
+
+		<!-- Detail panels -->
+		<div class="space-y-7">
+			<!-- Work -->
+			<BpBox label="Employment" i={1} cls="p-6 pt-7">
+				<div class="space-y-6">
+					{#each cvData.experience.work as org}
+						{#each org.roles as role}
+							<div class="border-l-2 pl-4" style="border-color: var(--bp-ink);">
+								<h4 class="bp-title text-base" style="color: var(--bp-ink-strong);">
+									{role.role} — {org.organization}
+								</h4>
+								<p class="mb-2 text-[11px]" style="color: var(--bp-red);">
+									{role.duration}{#if org.location} · {org.location}{/if}
+								</p>
+								<ul class="space-y-1.5">
+									{#each asList(role.responsibilities) as resp}
+										<li class="bp-callout text-[12px]">{resp}</li>
+									{/each}
+								</ul>
+							</div>
+						{/each}
+					{/each}
+				</div>
+			</BpBox>
+
+			<!-- Academia -->
+			<BpBox label="Academic" i={2} cls="p-6 pt-7">
+				<div class="space-y-6">
+					{#each cvData.experience.academia as org}
+						{#each org.roles as role}
+							<div class="border-l-2 pl-4" style="border-color: var(--bp-ink);">
+								<h4 class="bp-title text-base" style="color: var(--bp-ink-strong);">
+									{role.role} — {org.organization}
+								</h4>
+								<p class="mb-2 text-[11px]" style="color: var(--bp-red);">{role.duration}</p>
+								<ul class="space-y-1.5">
+									{#each asList(role.responsibilities) as resp}
+										<li class="bp-callout text-[12px]">{resp}</li>
+									{/each}
+								</ul>
+							</div>
+						{/each}
+					{/each}
+				</div>
+			</BpBox>
+
+			<!-- Education -->
+			<BpBox label="Education" i={3} cls="p-6 pt-7">
+				<div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+					{#each cvData.education as edu}
+						<div class="border-l-2 pl-4" style="border-color: var(--bp-ink);">
+							<h4 class="bp-title text-sm" style="color: var(--bp-ink-strong);">{edu.degree}</h4>
+							<p class="text-[12px]" style="color: var(--bp-graphite);">{edu.institution}</p>
+							<p class="mb-3 text-[11px]" style="color: var(--bp-red);">
+								{edu.duration} · GPA {edu.gpa}
+							</p>
+							<div class="flex flex-wrap gap-1.5">
+								{#each edu.coursework as course}
+									<span class="bp-chip" style="font-size: 10px;" use:drawEdges>{course}</span>
+								{/each}
+							</div>
+						</div>
+					{/each}
+				</div>
+			</BpBox>
+
+			<!-- Others -->
+			{#if cvData.experience.others?.length}
+				<BpBox label="Other" i={4} cls="p-6 pt-7">
+					<div class="space-y-6">
+						{#each cvData.experience.others as org}
+							{#each org.roles as role}
+								<div class="border-l-2 pl-4" style="border-color: var(--bp-ink);">
+									<h4 class="bp-title text-base" style="color: var(--bp-ink-strong);">
+										{role.role} — {org.organization}
+									</h4>
+									<p class="mb-2 text-[11px]" style="color: var(--bp-red);">{role.duration}</p>
+									<ul class="space-y-1.5">
+										{#each asList(role.responsibilities) as resp}
+											<li class="bp-callout text-[12px]">{resp}</li>
+										{/each}
+									</ul>
+								</div>
+							{/each}
+						{/each}
+					</div>
+				</BpBox>
+			{/if}
+		</div>
+	{:else}
+		<p class="text-xs" style="color: var(--bp-ink);">LOADING SHEET 04…</p>
+	{/if}
+</section>

--- a/src/lib/blueprint/BpHighlights.svelte
+++ b/src/lib/blueprint/BpHighlights.svelte
@@ -1,0 +1,81 @@
+<script>
+	import { onMount } from 'svelte';
+	import BpBox from './BpBox.svelte';
+	import { typewriter } from './typewriter.js';
+	import { drawEdges } from './drawEdges.js';
+	let highlightData = null;
+	let error = null;
+
+	onMount(async () => {
+		try {
+			const res = await fetch('/data/highlights.json');
+			highlightData = await res.json();
+		} catch (err) {
+			error = err;
+		}
+	});
+</script>
+
+<section class="bp-root">
+	{#if error}
+		<p style="color: var(--bp-red);">// DRAWING DATA NOT FOUND — REF highlights.json</p>
+	{:else if highlightData}
+		<!-- Sheet heading -->
+		<div class="bp-sheet-head" use:typewriter={{ done: 1260, duration: 700 }}>
+			<div>
+				<h1 class="bp-title text-2xl md:text-3xl">Highlights</h1>
+				<p class="mt-1 text-xs" style="color: var(--bp-ink);">
+					SHEET 02 — CAPABILITY INVENTORY
+				</p>
+			</div>
+			<p class="hidden text-right text-[10px] md:block" style="color: var(--bp-ink);">
+				ITEMS: {highlightData.skills.reduce((n, s) => n + s.items.length, 0)}<br />
+				GROUPS: {highlightData.skills.length}
+			</p>
+		</div>
+
+		<!-- BOM table -->
+		<BpBox i={0} cls="p-1">
+			<table class="bp-table">
+				<thead>
+					<tr>
+						<th style="width: 48px;">Item</th>
+						<th style="width: 220px;">Assembly</th>
+						<th>Components</th>
+						<th style="width: 56px;">Qty</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each highlightData.skills as group, i}
+						<tr>
+							<td style="font-weight: 700; color: var(--bp-ink);">
+								{String(i + 1).padStart(2, '0')}
+							</td>
+							<td style="font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em;">
+								{group.category}
+							</td>
+							<td>
+								<div class="flex flex-wrap gap-1.5">
+									{#each group.items as item}
+										<span class="bp-chip" use:drawEdges>{item}</span>
+									{/each}
+								</div>
+							</td>
+							<td style="text-align: center; color: var(--bp-ink);">{group.items.length}</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</BpBox>
+
+		<p
+			class="mt-3 text-right text-[10px]"
+			style="color: var(--bp-ink);"
+			use:typewriter={{ done: 3100, duration: 350 }}
+		>
+			— END OF PARTS LIST —
+		</p>
+	{:else}
+		<p class="text-xs" style="color: var(--bp-ink);">LOADING SHEET 02…</p>
+	{/if}
+</section>

--- a/src/lib/blueprint/BpProjects.svelte
+++ b/src/lib/blueprint/BpProjects.svelte
@@ -1,0 +1,100 @@
+<script>
+	import { onMount } from 'svelte';
+	import BpBox from './BpBox.svelte';
+	import { typewriter } from './typewriter.js';
+	import { drawEdges } from './drawEdges.js';
+	let projectData = null;
+	let error = null;
+
+	onMount(async () => {
+		try {
+			const res = await fetch('/data/projects.json');
+			projectData = await res.json();
+		} catch (err) {
+			error = err;
+		}
+	});
+</script>
+
+<section class="bp-root">
+	{#if error}
+		<p style="color: var(--bp-red);">// DRAWING DATA NOT FOUND — REF projects.json</p>
+	{:else if projectData}
+		<!-- Sheet heading -->
+		<div class="bp-sheet-head" use:typewriter={{ done: 1260, duration: 700 }}>
+			<div>
+				<h1 class="bp-title text-2xl md:text-3xl">Projects</h1>
+				<p class="mt-1 text-xs" style="color: var(--bp-ink);">
+					SHEET 03 — PROJECT DETAILS
+				</p>
+			</div>
+			<p class="hidden text-right text-[10px] md:block" style="color: var(--bp-ink);">
+				DETAILS: {projectData.projects.length}
+			</p>
+		</div>
+
+		<div class="grid grid-cols-1 gap-7 xl:grid-cols-2">
+			{#each projectData.projects as project, idx}
+				<BpBox label={`DET-${String(idx + 1).padStart(2, '0')}`} i={idx} cls="p-6 pt-7">
+					<!-- Title row with balloon -->
+					<div class="mb-4 flex items-start gap-3">
+						<span class="bp-balloon">{idx + 1}</span>
+						<h4 class="bp-title text-base leading-snug" style="color: var(--bp-ink-strong);">
+							{project.name}
+						</h4>
+					</div>
+
+					<!-- Description -->
+					{#each project.description as desc}
+						<p class="mb-4 text-[13px] leading-relaxed" style="color: var(--bp-graphite);">
+							{desc}
+						</p>
+					{/each}
+
+					<!-- Tech stack -->
+					<div class="mb-4">
+						<p class="mb-1.5 text-[10px] font-bold tracking-widest" style="color: var(--bp-ink);">
+							TECH STACK
+						</p>
+						<div class="flex flex-wrap gap-1.5">
+							{#each project.skillset as skill}
+								<span class="bp-chip" use:drawEdges>{skill}</span>
+							{/each}
+						</div>
+					</div>
+
+					<!-- Objectives -->
+					<div class="mb-4">
+						<p class="mb-1.5 text-[10px] font-bold tracking-widest" style="color: var(--bp-ink);">
+							OBJECTIVES
+						</p>
+						<ul class="space-y-1.5">
+							{#each project.objectives as objv}
+								<li class="bp-callout text-[12px]">{objv}</li>
+							{/each}
+						</ul>
+					</div>
+
+					<!-- Results -->
+					{#if project.results.length > 0}
+						<div class="border-t pt-3" style="border-color: var(--bp-line-soft);">
+							<p class="mb-1.5 text-[10px] font-bold tracking-widest" style="color: var(--bp-red);">
+								RESULTS
+							</p>
+							<ul class="space-y-1.5">
+								{#each project.results as res}
+									<li class="text-[12px]" style="color: var(--bp-graphite);">
+										<span class="font-bold" style="color: var(--bp-red);">✓</span>
+										{res}
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
+				</BpBox>
+			{/each}
+		</div>
+	{:else}
+		<p class="text-xs" style="color: var(--bp-ink);">LOADING SHEET 03…</p>
+	{/if}
+</section>

--- a/src/lib/blueprint/drawEdges.js
+++ b/src/lib/blueprint/drawEdges.js
@@ -1,0 +1,26 @@
+// Svelte action: give an element the same four-line "drawn box" treatment as
+// the panels — four edge spans plus a random draw order — so its border is
+// traced one line at a time (verticals-first or horizontals-first) by the
+// shared [data-order] > .e-* CSS, rather than two lines at once.
+export function drawEdges(node) {
+	const reduce =
+		typeof window !== 'undefined' &&
+		window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+	if (reduce) return { destroy() {} };
+
+	node.setAttribute('data-order', Math.random() < 0.5 ? 'v' : 'h');
+
+	const edges = ['e-top', 'e-bottom', 'e-left', 'e-right'].map((cls) => {
+		const s = document.createElement('span');
+		s.className = `bp-edge ${cls}`;
+		s.setAttribute('aria-hidden', 'true');
+		node.appendChild(s);
+		return s;
+	});
+
+	return {
+		destroy() {
+			edges.forEach((e) => e.remove());
+		}
+	};
+}

--- a/src/lib/blueprint/typewriter.js
+++ b/src/lib/blueprint/typewriter.js
@@ -1,0 +1,72 @@
+// Svelte action: reveal an element's text one character at a time, in reading
+// order, like a teletype. Each character sits faint until its turn, then snaps
+// to full dark. Word-wrapping and nested structure (chips, coloured spans) are
+// preserved — only text nodes are split, and each word is kept unbreakable.
+//
+// params:
+//   done     — ms after mount when typing starts (i.e. once the box is drawn)
+//   duration — ms over which this element's characters are all revealed
+//   enabled  — set false to skip (e.g. when not in blueprint motion mode)
+
+export function typewriter(node, params = {}) {
+	const reduce =
+		typeof window !== 'undefined' &&
+		window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+	if (reduce || params.enabled === false) {
+		return { update() {}, destroy() {} };
+	}
+
+	const chars = [];
+
+	function splitTextNode(textNode) {
+		const text = textNode.nodeValue;
+		if (!text) return;
+		const frag = document.createDocumentFragment();
+		// Keep whitespace runs as plain text (valid break points); wrap each
+		// word in a nowrap span so it never breaks mid-word once split.
+		for (const part of text.split(/(\s+)/)) {
+			if (part === '') continue;
+			if (/^\s+$/.test(part)) {
+				frag.appendChild(document.createTextNode(part));
+				continue;
+			}
+			const word = document.createElement('span');
+			word.style.whiteSpace = 'nowrap';
+			for (const ch of part) {
+				const c = document.createElement('span');
+				c.className = 'tw-char';
+				c.textContent = ch;
+				word.appendChild(c);
+				chars.push(c);
+			}
+			frag.appendChild(word);
+		}
+		textNode.replaceWith(frag);
+	}
+
+	function walk(el) {
+		for (const child of Array.from(el.childNodes)) {
+			if (child.nodeType === 3) splitTextNode(child);
+			else if (
+				child.nodeType === 1 &&
+				!child.classList.contains('tw-char') &&
+				// don't split icon ligatures or explicitly-skipped elements
+				!child.classList.contains('material-symbols-outlined') &&
+				!child.classList.contains('tw-skip')
+			)
+				walk(child);
+		}
+	}
+
+	walk(node);
+
+	const done = params.done ?? 0;
+	const duration = params.duration ?? 700;
+	const total = chars.length || 1;
+	chars.forEach((c, i) => {
+		c.style.animationDelay = `${Math.round(done + (i / total) * duration)}ms`;
+	});
+
+	return { update() {}, destroy() {} };
+}

--- a/src/lib/stores/theme.js
+++ b/src/lib/stores/theme.js
@@ -1,0 +1,29 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'portfolio-theme';
+const DEFAULT_THEME = 'retro';
+
+function createThemeStore() {
+	const initial = browser
+		? (localStorage.getItem(STORAGE_KEY) ?? DEFAULT_THEME)
+		: DEFAULT_THEME;
+
+	const { subscribe, set } = writable(initial);
+
+	if (browser) {
+		document.documentElement.dataset.theme = initial;
+	}
+
+	return {
+		subscribe,
+		toggle() {
+			const next = document.documentElement.dataset.theme === 'retro' ? 'blueprint' : 'retro';
+			document.documentElement.dataset.theme = next;
+			localStorage.setItem(STORAGE_KEY, next);
+			set(next);
+		}
+	};
+}
+
+export const theme = createThemeStore();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,14 @@
 <script>
 	import '../app.css';
+	import { browser } from '$app/environment';
 
 	let { children } = $props();
+
+	// Apply stored theme immediately to avoid flash on load
+	if (browser) {
+		const saved = localStorage.getItem('portfolio-theme') ?? 'retro';
+		document.documentElement.dataset.theme = saved;
+	}
 </script>
 
 {@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,9 @@
 	import Highlights from '$lib/Highlights.svelte';
 	import CV from '$lib/CV.svelte';
 	import Projects from '$lib/Projects.svelte';
+	import ThemeToggle from '$lib/ThemeToggle.svelte';
+	import { theme } from '$lib/stores/theme.js';
+	import BlueprintShell from '$lib/blueprint/BlueprintShell.svelte';
 
 	// use a current section to display only selected tab
 	let currentSection = 'about';
@@ -123,6 +126,10 @@
 	});
 </script>
 
+{#if $theme === 'blueprint'}
+	<BlueprintShell />
+{:else}
+<!-- ============ RETRO THEME LAYOUT ============ -->
 <!-- Scanlines Overlay -->
 <div class="scanlines"></div>
 
@@ -169,7 +176,7 @@
 			class="container mx-auto flex max-w-[1200px] items-center justify-between px-6 py-4 md:px-10"
 		>
 			<!-- Nav Links - Terminal icon and logo name move with active section -->
-			<ul class="hidden items-center gap-4 md:flex lg:gap-6">
+			<ul class="hidden items-center gap-4 lg:flex lg:gap-6">
 				<li>
 					<button
 						on:click={() => navigateTo('about')}
@@ -236,8 +243,8 @@
 				</li>
 			</ul>
 
-			<!-- Mobile Menu - Shows terminal icon + logo + section name -->
-			<div class="flex items-center gap-3 md:hidden">
+			<!-- Compact Menu (below lg) - section dropdown + toggle + contact -->
+			<div class="flex items-center gap-3 lg:hidden">
 				<div
 					class="text-primary border-primary shadow-neon flex items-center gap-2 rounded-lg border px-3 py-2"
 				>
@@ -259,15 +266,26 @@
 						<option value="cv" class="bg-background text-foreground">CV</option>
 					</select>
 				</div>
+				<ThemeToggle />
+				<a
+					href="mailto:devsoham3@gmail.com"
+					title="Contact me"
+					class="bg-primary text-background hover:bg-foreground hover:shadow-neon flex h-10 w-10 items-center justify-center rounded transition-all"
+				>
+					<span class="material-symbols-outlined text-lg">mail</span>
+				</a>
 			</div>
 
-			<!-- Contact Button (Desktop) -->
-			<a
-				href="mailto:devsoham3@gmail.com"
-				class="bg-primary text-background hover:bg-foreground hover:shadow-neon font-prsst hidden h-10 items-center justify-center rounded px-6 text-sm tracking-widest transition-all md:flex"
-			>
-				CONTACT_ME
-			</a>
+			<!-- Desktop right side (lg+): theme toggle + contact -->
+			<div class="hidden items-center gap-3 lg:flex">
+				<ThemeToggle />
+				<a
+					href="mailto:devsoham3@gmail.com"
+					class="bg-primary text-background hover:bg-foreground hover:shadow-neon font-prsst flex h-10 items-center justify-center rounded px-6 text-sm tracking-widest transition-all"
+				>
+					CONTACT_ME
+				</a>
+			</div>
 		</div>
 	</nav>
 
@@ -409,6 +427,7 @@
 		{/if}
 	</footer>
 </div>
+{/if}
 
 <style>
 	/* Animated loading dots */


### PR DESCRIPTION
Introduce a second site theme — a clean technical-drawing aesthetic (black ink on off-white drafting paper) — switchable from the nav and persisted to localStorage. The existing retro/neon theme is unchanged.

Theme system
- Add a Svelte store (src/lib/stores/theme.js) that sets a data-theme attribute on <html> and persists the choice to localStorage; applied in +layout.svelte to avoid a flash on load.
- +page.svelte renders the new BlueprintShell when the blueprint theme is active, otherwise the retro layout.

Blueprint theme (src/lib/blueprint/, src/app.css)
- Rendered as an engineering drawing: a header box (nav/identity/tabs) and a body box (content + title block) that share a divider line so they read as one sheet. The body box re-keys per section so it redraws at the new content size instead of snapping.
- Sections mapped to drawing types, all driven by the portfolio-content JSON: About = general arrangement (orthographic photo viewport + leader-line notes), Highlights = bill of materials table, Projects = numbered assembly details, CV = revision-history table. Original section names are shown; engineering codenames live in the title block as easter eggs.
- Hand-drawn animation: every box (frame, panels, chips) traces its four edges one line at a time in a random vertical/horizontal-first order; circle balloons draw with a compass-style conic sweep. Boxes cascade, then text types in per character (typewriter action) over a faint pencil pass. Dimension rules and hatching draw end-to-end. All respect prefers-reduced-motion.
- Faint drafting dot-grid background; 45 degree details (oblique dimension ticks, SECTION A-A hatch swatch); drawn hatching behind the title block and at the bottom of sections so boxes pop (kept behind opaque elements so text stays readable).
- Selected nav tab is hatched with a white, black-outlined label for legibility. Active section button + CONTACT button in the header.

Theme-switch buttons preview their target
- In blueprint, the RETRO MODE button uses the retro look (dark panel, neon-cyan glow, arcade font, gamepad icon).
- In retro, the BLUEPRINT button uses the blueprint look (paper/black, monospace, sharp corners, compass icon).

Retro nav fix
- Below ~1024px the full horizontal nav overflowed and clipped the CONTACT_ME button; it now collapses to a compact menu with a contact icon so contact is always reachable.

New reusable pieces: BpBox.svelte (drawn box wrapper), typewriter.js and drawEdges.js (Svelte actions). Add .claude/ and .mcp.json to .gitignore.